### PR TITLE
FIX

### DIFF
--- a/web_google_maps/static/src/js/view/map_view_places_autocomplete.js
+++ b/web_google_maps/static/src/js/view/map_view_places_autocomplete.js
@@ -38,7 +38,7 @@ odoo.define('web.MapViewPlacesAutocomplete', function (require) {
     function odoo_prepare_values(model, field_name, value) {
         var def = $.Deferred();
         var res = {};
-        if (model) {
+        if (model && value) {
             new Model(model).call('search', [['|', ['name', '=', value], ['code', '=', value]]]).done(function (record) {
                 res[field_name] = record.length > 0 ? record[0] : false;
                 def.resolve(res);
@@ -73,7 +73,7 @@ odoo.define('web.MapViewPlacesAutocomplete', function (require) {
                     values[field] = val;
                 }
             } else {
-                values[field] = place[option];
+                values[field] = place[option] || "";
             }
         });
         return values;
@@ -229,7 +229,7 @@ odoo.define('web.MapViewPlacesAutocomplete', function (require) {
                         def.resolve(values);
                     });
                 }).fail(function () {
-                    console.log('failed!');
+                    console.log("Couldn't get marker position!");
                     def.reject();
                 });
             }
@@ -274,7 +274,7 @@ odoo.define('web.MapViewPlacesAutocomplete', function (require) {
                 self.on_set_marker_animation();
                 self.marker_infowindow.close();
                 self.place_marker.setVisible(false);
-                var place = self.place_automplete.getPlace();
+                var place = this.getPlace();
                 if (!place.geometry) {
                     // User entered the name of a Place that was not suggested and
                     // pressed the Enter key, or the Place Details request failed.
@@ -403,6 +403,10 @@ odoo.define('web.MapViewPlacesAutocomplete', function (require) {
             }
             return def;
         },
+        destroy: function() {
+            google.maps.event.clearInstanceListeners(this.place_automplete);
+            this._super.apply(this, arguments);
+        }
     });
 
     return {

--- a/web_google_maps/static/src/js/widget/google_places_autocomplete_widget.js
+++ b/web_google_maps/static/src/js/widget/google_places_autocomplete_widget.js
@@ -5,7 +5,6 @@ odoo.define('web_google_maps.GooglePlacesAutocomplete', function (require) {
     var form_widgets = require('web.form_widgets');
     var ajax = require('web.ajax');
     var MapViewPlacesAutocomplete = require('web.MapViewPlacesAutocomplete');
-    var Model = require('web.Model');
     var _t = core._t;
 
 
@@ -154,6 +153,10 @@ odoo.define('web_google_maps.GooglePlacesAutocomplete', function (require) {
                 }
             }
             return true;
+        },
+        destroy_content: function () {
+            google.maps.event.clearInstanceListeners(this.places_autocomplete);
+            this._super.apply(this, arguments);
         }
     });
 

--- a/web_google_maps/static/src/js/widget/google_places_widget.js
+++ b/web_google_maps/static/src/js/widget/google_places_widget.js
@@ -159,6 +159,10 @@ odoo.define('web_google_maps.GooglePlacesFormAddress', function (require) {
                 self.do_warn(_t('The following fields are invalid:'), _t('<ul><li>' + unknown_fields.join('</li><li>') + '</li></ul>'));
                 return false;
             }
+        },
+        destroy_content: function() {
+            google.maps.event.clearInstanceListeners(this.places_autocomplete);
+            this._super.apply(this, arguments);
         }
     });
 


### PR DESCRIPTION
- Fixed an issue found on gplaces_autocomplete widget, it throw an error if there is a value expected(the one defined on fullfields) is not exists in a values return by google places autocomplete.
- Override 'destroy_content' on both widgets (gplaces_autocomplete and gplaces_address_form) to clear google event listener from places instance