### PR TITLE
IMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <div align="center">
     <h3>Odoo Community version 10.0</h3>
     <p>Custom modules I made for Odoo</p>
-    <p>You can buy me a cup of <a href="http://ko-fi.com/yopiangi">☕</a>, if you want to support me to keep this project maintained. Thanks :)</p>
+    <p><a href="https://ko-fi.com/P5P4FOM0" target="_blank"><img src="https://www.ko-fi.com/img/donate_sm.png" alt="ko-fi"/></a></p>
+    <p>if you want to support me to keep this project maintained. Thanks :)</p>
 </div>

--- a/web_google_maps/README.md
+++ b/web_google_maps/README.md
@@ -1,7 +1,7 @@
 Web Google Maps
 ===============   
 
-[![Demo](https://i.ytimg.com/vi/2UdG5ILDtiY/3.jpg)](https://youtu.be/2UdG5ILDtiY "Demo")    
+[![Demo](https://i.ytimg.com/vi/2UdG5ILDtiY/3.jpg)](https://youtu.be/5hvAubXgUnc "Demo")    
 
 
 This module contains three new features:
@@ -279,7 +279,7 @@ The goal of this module is to bring the power of Google Maps into Odoo
 This module has tested on Odoo Version 10.0c    
 
 
-You can buy me a cup of [☕](http://ko-fi.com/yopiangi), if you want to support me to keep this project maintained. Thanks :)
+[![ko-fi](https://www.ko-fi.com/img/donate_sm.png)](https://ko-fi.com/P5P4FOM0), if you want to support me to keep this project maintained. Thanks :)
 
 Regards,  
 Yopi  

--- a/web_google_maps/i18n/web_google_maps.pot
+++ b/web_google_maps/i18n/web_google_maps.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-12 07:08+0000\n"
-"PO-Revision-Date: 2017-08-12 07:08+0000\n"
+"POT-Creation-Date: 2018-07-23 11:14+0000\n"
+"PO-Revision-Date: 2018-07-23 11:14+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -27,6 +27,33 @@ msgstr ""
 #: code:addons/web_google_maps/static/src/xml/widget_places.xml:66
 #, python-format
 msgid "All"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Arabic"
+msgstr ""
+
+#. module: web_google_maps
+#. openerp-web
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:1559
+#, python-format
+msgid "Are you sure you want to delete this record ?"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_theme:0
+msgid "Aubergine"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Basque"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Bengali"
 msgstr ""
 
 #. module: web_google_maps
@@ -51,6 +78,26 @@ msgid "Bike"
 msgstr ""
 
 #. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Bulgarian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Catalan"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Chinese (Traditional)"
+msgstr ""
+
+#. module: web_google_maps
 #. openerp-web
 #: code:addons/web_google_maps/static/src/xml/widget_places.xml:83
 #, python-format
@@ -58,8 +105,34 @@ msgid "Create Partner"
 msgstr ""
 
 #. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Croatian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Czech"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Danish"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_theme:0
+msgid "Dark"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_theme:0
+msgid "Default"
+msgstr ""
+
+#. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/static/src/js/view/map_view.js:283
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:388
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:1361
 #, python-format
 msgid "Directions request failed due to "
 msgstr ""
@@ -72,6 +145,26 @@ msgid "Driving"
 msgstr ""
 
 #. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Dutch"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "English"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "English (Australian)"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "English (Great Britain)"
+msgstr ""
+
+#. module: web_google_maps
 #. openerp-web
 #: code:addons/web_google_maps/static/src/xml/widget_places.xml:75
 #, python-format
@@ -80,7 +173,8 @@ msgstr ""
 
 #. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/static/src/js/view/map_view.js:48
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:104
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:944
 #, python-format
 msgid "Error: cannot display locations"
 msgstr ""
@@ -94,11 +188,36 @@ msgstr ""
 
 #. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/static/src/js/view/map_view_places_autocomplete.js:365
-#: code:addons/web_google_maps/static/src/js/view/map_view_places_autocomplete.js:371
-#: code:addons/web_google_maps/static/src/js/view/map_view_places_autocomplete.js:374
+#: code:addons/web_google_maps/static/src/js/view/map_view_places_autocomplete.js:353
+#: code:addons/web_google_maps/static/src/js/view/map_view_places_autocomplete.js:359
+#: code:addons/web_google_maps/static/src/js/view/map_view_places_autocomplete.js:362
 #, python-format
 msgid "Fail to create new partner!"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Farsi"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Filipino"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Finnish"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "French"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Galician"
 msgstr ""
 
 #. module: web_google_maps
@@ -106,6 +225,11 @@ msgstr ""
 #: code:addons/web_google_maps/static/src/xml/widget_places.xml:72
 #, python-format
 msgid "Geocodes"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "German"
 msgstr ""
 
 #. module: web_google_maps
@@ -124,8 +248,13 @@ msgid "Google Maps Region Localization"
 msgstr ""
 
 #. module: web_google_maps
+#: model:ir.ui.view,arch_db:web_google_maps.view_website_config_settings_inherit
+msgid "Google Maps Theme"
+msgstr ""
+
+#. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/static/src/js/widget/google_places_autocomplete_widget.js:14
+#: code:addons/web_google_maps/static/src/js/widget/google_places_autocomplete_widget.js:13
 #, python-format
 msgid "Google Places"
 msgstr ""
@@ -138,13 +267,68 @@ msgid "Google Places Form Address"
 msgstr ""
 
 #. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Greek"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Gujarati"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Hebrew"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Hindi"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Hungarian"
+msgstr ""
+
+#. module: web_google_maps
 #: model:ir.ui.view,arch_db:web_google_maps.view_website_config_settings_inherit
 msgid "If you set the language of the map, it's important to consider setting the region too."
 msgstr ""
 
 #. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Indonesian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Italian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Japanese"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Kannada"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Korean"
+msgstr ""
+
+#. module: web_google_maps
 #: model:ir.ui.view,arch_db:web_google_maps.view_website_config_settings_inherit
 msgid "Language"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Latvian"
 msgstr ""
 
 #. module: web_google_maps
@@ -155,13 +339,23 @@ msgid "Layers"
 msgstr ""
 
 #. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Lithuanian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Malayalam"
+msgstr ""
+
+#. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/models/ir_actions_act_window.py:8
-#: code:addons/web_google_maps/models/ir_ui_view.py:8
-#: code:addons/web_google_maps/models/res_partner.py:25
-#: code:addons/web_google_maps/static/src/js/view/map_view.js:16
-#: model:ir.actions.act_window,name:web_google_maps.act_res_partner_map
-#: model:ir.ui.view,arch_db:web_google_maps.view_partner_form
+#: code:addons/web_google_maps/models/ir_actions_act_window.py:9
+#: code:addons/web_google_maps/models/ir_actions_act_window_view.py:9
+#: code:addons/web_google_maps/models/ir_ui_view.py:9
+#: code:addons/web_google_maps/models/res_partner.py:26
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:26
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:814
 #: model:ir.ui.view,arch_db:web_google_maps.view_partner_map
 #, python-format
 msgid "Map"
@@ -176,16 +370,44 @@ msgstr ""
 
 #. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/static/src/js/view/map_view_places_autocomplete.js:281
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:112
+#, python-format
+msgid "Map View Attributes"
+msgstr ""
+
+#. module: web_google_maps
+#: model:ir.model.fields,field_description:web_google_maps.field_website_config_settings_google_maps_theme
+msgid "Map theme"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Marathi"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_theme:0
+msgid "Night"
+msgstr ""
+
+#. module: web_google_maps
+#. openerp-web
+#: code:addons/web_google_maps/static/src/js/view/map_view_places_autocomplete.js:262
 #, python-format
 msgid "No details available for input: ''"
 msgstr ""
 
 #. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/static/src/js/view/map_view.js:64
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:169
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:992
 #, python-format
 msgid "No geolocation is found!"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Norwegian"
 msgstr ""
 
 #. module: web_google_maps
@@ -202,9 +424,30 @@ msgstr ""
 
 #. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/static/src/js/view/map_view.js:48
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:104
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:944
 #, python-format
 msgid "Please define alias name for geolocations fields for map view!"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Polish"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Portuguese"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Portuguese (Brazil)"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Portuguese (Portugal)"
 msgstr ""
 
 #. module: web_google_maps
@@ -227,15 +470,51 @@ msgid "Reload"
 msgstr ""
 
 #. module: web_google_maps
+#: selection:website.config.settings,google_maps_theme:0
+msgid "Retro"
+msgstr ""
+
+#. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/static/src/js/view/map_view.js:362
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:470
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:1443
 #, python-format
 msgid "Reverse geocoding is failed!"
 msgstr ""
 
 #. module: web_google_maps
-#: model:ir.ui.view,arch_db:web_google_maps.view_partner_form
-msgid "Route"
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Romanian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Russian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Serbian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_theme:0
+msgid "Silver"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Slovak"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Slovenian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Spanish"
 msgstr ""
 
 #. module: web_google_maps
@@ -247,17 +526,56 @@ msgstr ""
 
 #. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/static/src/js/view/map_view_places_autocomplete.js:359
+#: code:addons/web_google_maps/static/src/js/view/map_view_places_autocomplete.js:347
 #, python-format
 msgid "Successfully created new partner"
 msgstr ""
 
 #. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Swedish"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Tagalog"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Tamil"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Telugu"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Thai"
+msgstr ""
+
+#. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/static/src/js/widget/google_places_autocomplete_widget.js:152
+#: code:addons/web_google_maps/static/src/js/view/map_view.js:112
+#, python-format
+msgid "The field for marker title needs to be loaded into view!"
+msgstr ""
+
+#. module: web_google_maps
+#. openerp-web
+#: code:addons/web_google_maps/static/src/js/widget/google_places_autocomplete_widget.js:155
+#: code:addons/web_google_maps/static/src/js/widget/google_places_autocomplete_widget.js:168
 #: code:addons/web_google_maps/static/src/js/widget/google_places_widget.js:159
+#: code:addons/web_google_maps/static/src/js/widget/google_places_widget.js:166
 #, python-format
 msgid "The following fields are invalid:"
+msgstr ""
+
+#. module: web_google_maps
+#: model:ir.ui.view,arch_db:web_google_maps.view_website_config_settings_inherit
+msgid "Theme"
 msgstr ""
 
 #. module: web_google_maps
@@ -288,6 +606,21 @@ msgid "Travel Mode"
 msgstr ""
 
 #. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Turkish"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Ukrainian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:website.config.settings,google_maps_lang_localization:0
+msgid "Vietnamese"
+msgstr ""
+
+#. module: web_google_maps
 #: model:ir.ui.view,arch_db:web_google_maps.view_website_config_settings_inherit
 msgid "Visit the"
 msgstr ""
@@ -300,7 +633,7 @@ msgid "Walking"
 msgstr ""
 
 #. module: web_google_maps
-#: code:addons/web_google_maps/models/res_partner.py:14
+#: code:addons/web_google_maps/models/res_partner.py:15
 #, python-format
 msgid "You have not defined your geolocation"
 msgstr ""
@@ -311,6 +644,32 @@ msgid "about Localizing the Map"
 msgstr ""
 
 #. module: web_google_maps
+#: model:ir.ui.view,arch_db:web_google_maps.view_partner_map
+msgid "at"
+msgstr ""
+
+#. module: web_google_maps
+#: model:ir.model,name:web_google_maps.model_ir_actions_act_window
+msgid "ir.actions.act_window"
+msgstr ""
+
+#. module: web_google_maps
+#: model:ir.model,name:web_google_maps.model_ir_actions_act_window_view
+msgid "ir.actions.act_window.view"
+msgstr ""
+
+#. module: web_google_maps
+#: model:ir.model,name:web_google_maps.model_ir_ui_view
+msgid "ir.ui.view"
+msgstr ""
+
+#. module: web_google_maps
 #: model:ir.ui.view,arch_db:web_google_maps.view_website_config_settings_inherit
 msgid "page"
 msgstr ""
+
+#. module: web_google_maps
+#: model:ir.model,name:web_google_maps.model_website_config_settings
+msgid "website.config.settings"
+msgstr ""
+

--- a/web_google_maps/static/description/index.html
+++ b/web_google_maps/static/description/index.html
@@ -5,7 +5,7 @@
         <div class="oe_span12">
             <img class="oe_picture oe_screenshot" src="maps.png">
             <div class="text-center">
-                <a href="https://youtu.be/2UdG5ILDtiY" class="btn btn-primary" target="_blank">Demo Video</a>
+                <a href="https://youtu.be/5hvAubXgUnc" class="btn btn-primary" target="_blank">Demo Video</a>
             </div>
         </div>
         <div class="oe_span12">
@@ -105,6 +105,10 @@
         <div class="oe_span12">
             <h3>Maintainer</h3>
             <p>This module is maintained by myself, if you are interested to contribute please let me know</p>
+            <script type='text/javascript' src='https://ko-fi.com/widgets/widget_2.js'></script>
+            <a href="https://ko-fi.com/P5P4FOM0" target="_blank">
+                <img src="https://www.ko-fi.com/img/donate_sm.png" alt="ko-fi"/>
+            </a>
             <p>Thank you</p>
         </div>
     </div>

--- a/web_google_maps/static/src/js/view/map_view.js
+++ b/web_google_maps/static/src/js/view/map_view.js
@@ -1101,33 +1101,36 @@ odoo.define('web.MapView', function (require) {
                 });
             }
             this.marker_cluster.addMarker(marker);
-            google.maps.event.addListener(marker, 'click', this.marker_infowindow(marker, existing_records));
+            google.maps.event.addListener(marker, 'click', this.marker_infowindow.bind(this, marker, existing_records));
         },
         marker_infowindow: function (marker, current_records) {
             var self = this;
             var _content = '';
             var marker_records = [];
 
-            var div_content = document.createElement('div');
-            div_content.className = 'o_kanban_view';
-            div_content.style.cssText = 'display:block;max-height:400px;overflow-y:auto;width:350px;';
+            var marker_content = document.createElement('div');
+            marker_content.className = 'o_kanban_view o_kanban_grouped';
+
+            var content_body = document.createElement('div');
+            content_body.className = 'o_kanban_group';
 
             if (current_records.length > 0) {
                 current_records.forEach(function (_record) {
                     _content = self.marker_infowindow_content(_record);
                     marker_records.push(_content);
-                    _content.appendTo(div_content);
+                    _content.appendTo(content_body);
                 });
             }
 
             var marker_record = self.marker_infowindow_content(marker._odoo_record);
-            marker_record.appendTo(div_content);
+            marker_record.appendTo(content_body);
             marker_records.push(marker_record);
-            return function () {
-                self.infowindow.setContent(div_content);
-                self.infowindow.open(self.map, marker);
-                self.postprocess_m2m_tags(marker_records);
-            }
+
+            marker_content.appendChild(content_body);
+
+            this.infowindow.setContent(marker_content);
+            this.infowindow.open(this.map, marker);
+            this.postprocess_m2m_tags(marker_records);
         },
         marker_infowindow_content: function (record) {
             var options = _.clone(this.record_options);


### PR DESCRIPTION
- Speed up the load times the map view takes to finished load all markers. Only when marker is clicked the qweb template used for marker infowindow will be generated.
- Removed the fixed `CSS` style added to marker infowindow and replaced it with `kanban` style