### PR TITLE
Fix autocomplete extreme call

### DIFF
--- a/web_google_maps/__manifest__.py
+++ b/web_google_maps/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Web Google Maps',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.2',
     'author': 'Yopi Angi',
     'license': 'AGPL-3',
     'maintainer': 'Yopi Angi<yopiangi@gmail.com>',

--- a/web_google_maps/controllers/main.py
+++ b/web_google_maps/controllers/main.py
@@ -1,12 +1,27 @@
 # -*- coding: utf-8 -*-
 from odoo import http
+from odoo.tools import safe_eval
 
 
 class Main(http.Controller):
 
-    @http.route('/web/map_theme', type='json', auth='user')
+    @http.route('/web/google_map_theme', type='json', auth='user')
     def map_theme(self):
         ICP = http.request.env['ir.config_parameter'].sudo()
-        theme = ICP.get_param('google.maps_theme', default='default')
+        theme = ICP.get_param('web_google_maps.map_theme', default='default')
         res = {'theme': theme}
         return res
+
+    @http.route('/web/google_autocomplete_conf', type='json', auth='user')
+    def google_autocomplete_settings(self):
+        get_param = http.request.env['ir.config_parameter'].sudo().get_param
+        is_lang_restrict = safe_eval(get_param(
+            'web_google_maps.autocomplete_lang_restrict', default='False'))
+        lang = get_param(
+            'web_google_maps.localization_lang', default=False)
+
+        result = {}
+        if is_lang_restrict and lang:
+            result['language'] = lang
+
+        return result

--- a/web_google_maps/data/google_maps_libraries.xml
+++ b/web_google_maps/data/google_maps_libraries.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <function model="ir.config_parameter" name="set_param" eval="('google.maps_libraries', 'geometry,places')"/>
+        <function model="ir.config_parameter" name="set_param" eval="('web_google_maps.maps_libraries', 'geometry,places')"/>
     </data>
 </odoo>

--- a/web_google_maps/i18n/web_google_maps.pot
+++ b/web_google_maps/i18n/web_google_maps.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-24 13:56+0000\n"
-"PO-Revision-Date: 2019-02-24 13:56+0000\n"
+"POT-Creation-Date: 2019-12-29 14:22+0000\n"
+"PO-Revision-Date: 2019-12-29 14:22+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,8 +17,8 @@ msgstr ""
 
 #. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js:303
-#: code:addons/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js:476
+#: code:addons/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js:322
+#: code:addons/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js:479
 #, python-format
 msgid "<ul><li></li></ul>"
 msgstr ""
@@ -35,6 +35,21 @@ msgid "Activity"
 msgstr ""
 
 #. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Afrikaans"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Albanian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Amharic"
+msgstr ""
+
+#. module: web_google_maps
 #: model_terms:ir.ui.view,arch_db:web_google_maps.res_config_settings_view_form
 msgid "Api key"
 msgstr ""
@@ -45,8 +60,18 @@ msgid "Arabic"
 msgstr ""
 
 #. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Armenian"
+msgstr ""
+
+#. module: web_google_maps
 #: selection:res.config.settings,google_maps_theme:0
 msgid "Aubergine"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Azerbaijani"
 msgstr ""
 
 #. module: web_google_maps
@@ -56,12 +81,27 @@ msgstr ""
 
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Belarusian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
 msgid "Bengali"
 msgstr ""
 
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Bosnian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
 msgid "Bulgarian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Burmese"
 msgstr ""
 
 #. module: web_google_maps
@@ -73,6 +113,16 @@ msgstr ""
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
 msgid "Catalan"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Chinese"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Chinese (Hong Kong)"
 msgstr ""
 
 #. module: web_google_maps
@@ -121,6 +171,22 @@ msgid "Diagram"
 msgstr ""
 
 #. module: web_google_maps
+#: model:ir.model.fields,field_description:web_google_maps.field_res_config_settings__google_maps_lib_drawing
+msgid "Drawing"
+msgstr ""
+
+#. module: web_google_maps
+#: model_terms:ir.ui.view,arch_db:web_google_maps.res_config_settings_view_form
+msgid "Drawing library documentation"
+msgstr ""
+
+#. module: web_google_maps
+#: model_terms:ir.ui.view,arch_db:web_google_maps.res_config_settings_view_form
+msgid "Drawing provides a graphical interface for users to draw polygons, rectangles, polylines, circles, and markers on the map.\n"
+"                                        Consult the"
+msgstr ""
+
+#. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
 msgid "Dutch"
 msgstr ""
@@ -138,6 +204,11 @@ msgstr ""
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
 msgid "English (Great Britain)"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Estonian"
 msgstr ""
 
 #. module: web_google_maps
@@ -168,6 +239,11 @@ msgstr ""
 
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
+msgid "French (Canada)"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
 msgid "Galician"
 msgstr ""
 
@@ -178,7 +254,7 @@ msgid "Gantt"
 msgstr ""
 
 #. module: web_google_maps
-#: model:ir.model.fields,field_description:web_google_maps.field_res_config_settings__google_maps_geometry
+#: model:ir.model.fields,field_description:web_google_maps.field_res_config_settings__google_maps_lib_geometry
 msgid "Geometry"
 msgstr ""
 
@@ -195,7 +271,17 @@ msgstr ""
 
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Georgian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
 msgid "German"
+msgstr ""
+
+#. module: web_google_maps
+#: model:ir.model.fields,field_description:web_google_maps.field_res_config_settings__google_autocomplete_lang_restrict
+msgid "Google Autocomplete Language Restriction"
 msgstr ""
 
 #. module: web_google_maps
@@ -255,6 +341,11 @@ msgid "Hungarian"
 msgstr ""
 
 #. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Icelandic"
+msgstr ""
+
+#. module: web_google_maps
 #: model_terms:ir.ui.view,arch_db:web_google_maps.res_config_settings_view_form
 msgid "If you set the language of the map, it's important to consider setting the region too. This helps ensure that your application complies with local laws."
 msgstr ""
@@ -287,12 +378,32 @@ msgstr ""
 
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Kazakh"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Khmer"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
 msgid "Korean"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Kyrgyz"
 msgstr ""
 
 #. module: web_google_maps
 #: model_terms:ir.ui.view,arch_db:web_google_maps.res_config_settings_view_form
 msgid "Language"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Lao"
 msgstr ""
 
 #. module: web_google_maps
@@ -303,6 +414,16 @@ msgstr ""
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
 msgid "Lithuanian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Macedonian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Malay"
 msgstr ""
 
 #. module: web_google_maps
@@ -331,6 +452,16 @@ msgid "Marathi"
 msgstr ""
 
 #. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Mongolian"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Nepali"
+msgstr ""
+
+#. module: web_google_maps
 #: selection:res.config.settings,google_maps_theme:0
 msgid "Night"
 msgstr ""
@@ -347,7 +478,7 @@ msgid "Pivot"
 msgstr ""
 
 #. module: web_google_maps
-#: model:ir.model.fields,field_description:web_google_maps.field_res_config_settings__google_maps_places
+#: model:ir.model.fields,field_description:web_google_maps.field_res_config_settings__google_maps_lib_places
 msgid "Places"
 msgstr ""
 
@@ -380,6 +511,11 @@ msgstr ""
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
 msgid "Portuguese (Portugal)"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Punjabi"
 msgstr ""
 
 #. module: web_google_maps
@@ -429,6 +565,11 @@ msgstr ""
 
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Sinhalese"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
 msgid "Slovak"
 msgstr ""
 
@@ -444,12 +585,17 @@ msgstr ""
 
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
-msgid "Swedish"
+msgid "Spanish (Latin America)"
 msgstr ""
 
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
-msgid "Tagalog"
+msgid "Swahili"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Swedish"
 msgstr ""
 
 #. module: web_google_maps
@@ -469,10 +615,15 @@ msgstr ""
 
 #. module: web_google_maps
 #. openerp-web
-#: code:addons/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js:303
-#: code:addons/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js:476
+#: code:addons/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js:322
+#: code:addons/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js:479
 #, python-format
 msgid "The following fields are invalid:"
+msgstr ""
+
+#. module: web_google_maps
+#: model_terms:ir.ui.view,arch_db:web_google_maps.res_config_settings_view_form
+msgid "The language code, indicating in which language the results should be returned, if possible. Searches are also biased to the selected language; results in the selected language may be given a higher ranking."
 msgstr ""
 
 #. module: web_google_maps
@@ -498,6 +649,16 @@ msgstr ""
 
 #. module: web_google_maps
 #: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Urdu"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Uzbek"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
 msgid "Vietnamese"
 msgstr ""
 
@@ -515,6 +676,27 @@ msgstr ""
 #. module: web_google_maps
 #: model_terms:ir.ui.view,arch_db:web_google_maps.res_config_settings_view_form
 msgid "Visit the"
+msgstr ""
+
+#. module: web_google_maps
+#: model:ir.model.fields,field_description:web_google_maps.field_res_config_settings__google_maps_lib_visualization
+msgid "Visualization"
+msgstr ""
+
+#. module: web_google_maps
+#: model_terms:ir.ui.view,arch_db:web_google_maps.res_config_settings_view_form
+msgid "Visualization library documentation"
+msgstr ""
+
+#. module: web_google_maps
+#: model_terms:ir.ui.view,arch_db:web_google_maps.res_config_settings_view_form
+msgid "Visualization provides heatmaps for visual representation of data.\n"
+"                                        Consult the"
+msgstr ""
+
+#. module: web_google_maps
+#: selection:res.config.settings,google_maps_lang_localization:0
+msgid "Zulu"
 msgstr ""
 
 #. module: web_google_maps

--- a/web_google_maps/migrations/12.0.1.0.2/post-migrate.py
+++ b/web_google_maps/migrations/12.0.1.0.2/post-migrate.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+def migrate(cr, version):
+    cr.execute("""
+    UPDATE ir_config_parameter SET key = 'web_google_maps.maps_libraries' WHERE key = 'google.maps_libraries';
+    """)
+    cr.execute("""
+    UPDATE ir_config_parameter SET key = 'web_google_maps.map_theme' WHERE key = 'google.maps_theme';
+    """)
+    cr.execute("""
+    UPDATE ir_config_parameter SET key = 'web_google_maps.localization_lang' WHERE key = 'google.lang_localization';
+    """)
+    cr.execute("""
+    UPDATE ir_config_parameter SET key = 'web_google_maps.localization_region' WHERE key = 'google.region_localization';
+    """)

--- a/web_google_maps/models/res_config_settings.py
+++ b/web_google_maps/models/res_config_settings.py
@@ -96,13 +96,17 @@ class ResConfigSettings(models.TransientModel):
         values = [(country.code, country.name) for country in country_ids]
         return values
 
-    google_maps_view_api_key = fields.Char(string='Google Maps View Api Key')
+    google_maps_view_api_key = fields.Char(
+        string='Google Maps View Api Key',
+        config_parameter='google.api_key_geocode')
     google_maps_lang_localization = fields.Selection(
         selection=GMAPS_LANG_LOCALIZATION,
-        string='Google Maps Language Localization')
+        string='Google Maps Language Localization',
+        config_parameter='web_google_maps.localization_lang')
     google_maps_region_localization = fields.Selection(
         selection=get_region_selection,
-        string='Google Maps Region Localization')
+        string='Google Maps Region Localization',
+        config_parameter='web_google_maps.localization_region')
     google_maps_theme = fields.Selection(
         selection=[('default', 'Default'),
                    ('aubergine', 'Aubergine'),
@@ -110,117 +114,98 @@ class ResConfigSettings(models.TransientModel):
                    ('dark', 'Dark'),
                    ('retro', 'Retro'),
                    ('silver', 'Silver')],
-        string='Map theme')
-    google_maps_places = fields.Boolean(string='Places', default=True)
-    google_maps_geometry = fields.Boolean(string='Geometry', default=True)
+        string='Map theme',
+        config_parameter='web_google_maps.map_theme')
+    google_autocomplete_lang_restrict = fields.Boolean(
+        string='Google Autocomplete Language Restriction',
+        config_parameter='web_google_maps.autocomplete_lang_restrict')
+    google_maps_lib_places = fields.Boolean(string='Places', default=True)
+    google_maps_lib_geometry = fields.Boolean(string='Geometry', default=True)
+    google_maps_lib_drawing = fields.Boolean(string='Drawing')
+    google_maps_lib_visualization = fields.Boolean(string='Visualization')
 
     @api.onchange('google_maps_lang_localization')
     def onchange_lang_localization(self):
         if not self.google_maps_lang_localization:
             self.google_maps_region_localization = ''
+            self.google_autocomplete_lang_restrict = False
 
     @api.multi
     def set_values(self):
         super(ResConfigSettings, self).set_values()
         ICPSudo = self.env['ir.config_parameter'].sudo()
-        lang_localization = self._set_google_maps_lang_localization()
-        region_localization = self._set_google_maps_region_localization()
 
         lib_places = self._set_google_maps_places()
         lib_geometry = self._set_google_maps_geometry()
+        lib_drawing = self._set_google_maps_drawing()
+        lib_visualize = self._set_google_maps_visualization()
 
-        active_libraries = '%s,%s' % (lib_geometry, lib_places)
+        active_libraries = ','.join(
+            filter(None, [lib_places, lib_geometry, lib_drawing, lib_visualize]))
 
-        ICPSudo.set_param('google.api_key_geocode',
-                          self.google_maps_view_api_key)
-        ICPSudo.set_param('google.lang_localization',
-                          lang_localization)
-        ICPSudo.set_param('google.region_localization',
-                          region_localization)
-        ICPSudo.set_param('google.maps_theme', self.google_maps_theme)
-        ICPSudo.set_param('google.maps_libraries', active_libraries)
+        ICPSudo.set_param('web_google_maps.maps_libraries', active_libraries)
 
     @api.model
     def get_values(self):
         res = super(ResConfigSettings, self).get_values()
-        ICPSudo = self.env['ir.config_parameter'].sudo()
-
-        lang_localization = self._get_google_maps_lang_localization()
-        region_localization = self._get_google_maps_region_localization()
 
         lib_places = self._get_google_maps_places()
         lib_geometry = self._get_google_maps_geometry()
+        lib_drawing = self._get_google_maps_drawing()
+        lib_visualize = self._get_google_maps_visualization()
 
         res.update({
-            'google_maps_view_api_key': ICPSudo.get_param(
-                'google.api_key_geocode', default=''),
-            'google_maps_lang_localization': lang_localization,
-            'google_maps_region_localization': region_localization,
-            'google_maps_theme': ICPSudo.get_param(
-                'google.maps_theme', default='default'),
-            'google_maps_places': lib_places,
-            'google_maps_geometry': lib_geometry
+            'google_maps_lib_places': lib_places,
+            'google_maps_lib_geometry': lib_geometry,
+            'google_maps_lib_drawing': lib_drawing,
+            'google_maps_lib_visualization': lib_visualize
         })
         return res
-
-    @api.multi
-    def _set_google_maps_lang_localization(self):
-        if self.google_maps_lang_localization:
-            lang_localization = '&language=%s' % \
-                                self.google_maps_lang_localization
-        else:
-            lang_localization = ''
-
-        return lang_localization
-
-    @api.model
-    def _get_google_maps_lang_localization(self):
-        ICPSudo = self.env['ir.config_parameter'].sudo()
-        google_maps_lang = ICPSudo.get_param(
-            'google.lang_localization', default='')
-        val = google_maps_lang.split('=')
-        lang = val and val[-1] or ''
-        return lang
-
-    @api.multi
-    def _set_google_maps_region_localization(self):
-        if self.google_maps_region_localization:
-            region_localization = '&region=%s' % \
-                                  self.google_maps_region_localization
-        else:
-            region_localization = ''
-
-        return region_localization
-
-    @api.model
-    def _get_google_maps_region_localization(self):
-        ICPSudo = self.env['ir.config_parameter'].sudo()
-        google_maps_region = ICPSudo.get_param(
-            'google.region_localization', default='')
-        val = google_maps_region.split('=')
-        region = val and val[-1] or ''
-        return region
 
     @api.model
     def _get_google_maps_geometry(self):
         ICPSudo = self.env['ir.config_parameter'].sudo()
         google_maps_libraries = ICPSudo.get_param(
-            'google.maps_libraries', default='')
+            'web_google_maps.maps_libraries', default='')
         libraries = google_maps_libraries.split(',')
         return 'geometry' in libraries
 
     @api.multi
     def _set_google_maps_geometry(self):
-        return 'geometry' if self.google_maps_geometry else ''
+        return 'geometry' if self.google_maps_lib_geometry else False
 
     @api.model
     def _get_google_maps_places(self):
         ICPSudo = self.env['ir.config_parameter'].sudo()
         google_maps_libraries = ICPSudo.get_param(
-            'google.maps_libraries', default='')
+            'web_google_maps.maps_libraries', default='')
         libraries = google_maps_libraries.split(',')
         return 'places' in libraries
 
     @api.multi
     def _set_google_maps_places(self):
-        return 'places' if self.google_maps_places else ''
+        return 'places' if self.google_maps_lib_places else False
+
+    @api.model
+    def _get_google_maps_drawing(self):
+        ICPSudo = self.env['ir.config_parameter'].sudo()
+        google_maps_libraries = ICPSudo.get_param(
+            'web_google_maps.maps_libraries', default='')
+        libraries = google_maps_libraries.split(',')
+        return 'drawing' in libraries
+
+    @api.multi
+    def _set_google_maps_drawing(self):
+        return 'drawing' if self.google_maps_lib_drawing else False
+
+    @api.model
+    def _get_google_maps_visualization(self):
+        ICPSudo = self.env['ir.config_parameter'].sudo()
+        google_maps_libraries = ICPSudo.get_param(
+            'web_google_maps.maps_libraries', default='')
+        libraries = google_maps_libraries.split(',')
+        return 'visualization' in libraries
+
+    @api.multi
+    def _set_google_maps_visualization(self):
+        return 'visualization' if self.google_maps_lib_visualization else False

--- a/web_google_maps/static/src/js/view/map/map_renderer.js
+++ b/web_google_maps/static/src/js/view/map/map_renderer.js
@@ -11,7 +11,6 @@ odoo.define('web_google_maps.MapRenderer', function (require) {
 
     var qweb = core.qweb;
 
-    var ICON_URL = '/web_google_maps/static/src/img/markers/';
     var MARKER_COLORS = [
         'green', 'yellow', 'blue', 'light-green',
         'red', 'magenta', 'black', 'purple', 'orange',
@@ -960,7 +959,7 @@ odoo.define('web_google_maps.MapRenderer', function (require) {
             }
             if (!this.theme) {
                 this._rpc({
-                    route: '/web/map_theme'
+                    route: '/web/google_map_theme'
                 }).then(function (data) {
                     if (data.theme && self.mapThemes.hasOwnProperty(data.theme)) {
                         self.theme = data.theme;

--- a/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js
+++ b/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js
@@ -27,7 +27,16 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
             this.fillfields = {};
             this.lng = false;
             this.lat = false;
+            this.autocomplete_settings = null;
             this.setDefault();
+        },
+        willStart: function () {
+            var self = this;
+            return this._rpc({
+                route: '/web/google_autocomplete_conf'
+            }).then(function (res) {
+                self.autocomplete_settings = res;
+            });
         },
         /**
          * @override
@@ -192,7 +201,7 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
 
     });
 
-    var GplaceAddressAutocompleteField = GplaceAutocomplete.extend({
+    var GplacesAddressAutocompleteField = GplaceAutocomplete.extend({
         className: 'o_field_char o_field_google_address_autocomplete',
         /**
          * @override
@@ -243,6 +252,7 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
         handlePopulateAddress: function () {
             var self = this;
             var place = this.places_autocomplete.getPlace();
+            console.log({place});
             if (place.hasOwnProperty('address_components')) {
                 var requests = [];
                 var google_address = this._populateAddress(place);
@@ -286,8 +296,12 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
             setTimeout(function () {
                 if (!self.places_autocomplete) {
                     self.places_autocomplete = new google.maps.places.Autocomplete(self.$input.get(0), {
-                        types: ['address']
+                        types: ['address'],
+                        fields: ['address_components', 'name', 'geometry']
                     });
+                    if (self.autocomplete_settings) {
+                        self.places_autocomplete.setOptions(self.autocomplete_settings);
+                    }
                 }
                 // When the user selects an address from the dropdown, populate the address fields in the form.
                 self.places_autocomplete.addListener('place_changed', self.handlePopulateAddress.bind(self));
@@ -438,8 +452,13 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
             setTimeout(function () {
                 if (!self.places_autocomplete) {
                     self.places_autocomplete = new google.maps.places.Autocomplete(self.$input.get(0), {
-                        types: ['establishment']
+                        types: ['establishment'],
+                        fields: ['address_components', 'name', 'website', 'geometry',
+                            'international_phone_number', 'formatted_phone_number'],
                     });
+                    if (self.autocomplete_settings) {
+                        self.places_autocomplete.setOptions(self.autocomplete_settings);
+                    }
                 }
                 // When the user selects an address from the dropdown, populate the address fields in the form.
                 self.places_autocomplete.addListener('place_changed', self.handlePopulateAddress.bind(self));
@@ -475,7 +494,7 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
     });
 
     return {
-        GplacesAddressAutocompleteField: GplaceAddressAutocompleteField,
+        GplacesAddressAutocompleteField: GplacesAddressAutocompleteField,
         GplacesAutocompleteField: GplacesAutocompleteField
     };
 

--- a/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js
+++ b/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js
@@ -32,11 +32,12 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
         },
         willStart: function () {
             var self = this;
-            return this._rpc({
+            var getSettings = this._rpc({
                 route: '/web/google_autocomplete_conf'
             }).then(function (res) {
                 self.autocomplete_settings = res;
             });
+            return $.when(this._super.apply(this, arguments), getSettings);
         },
         /**
          * @override
@@ -252,7 +253,6 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
         handlePopulateAddress: function () {
             var self = this;
             var place = this.places_autocomplete.getPlace();
-            console.log({place});
             if (place.hasOwnProperty('address_components')) {
                 var requests = [];
                 var google_address = this._populateAddress(place);

--- a/web_google_maps/views/google_places_template.xml
+++ b/web_google_maps/views/google_places_template.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="web_google_maps.assets_gmaps">
-        <t t-set="google_maps_api_key" t-value="request.env['ir.config_parameter'].sudo().get_param('google.api_key_geocode')"/>
-        <t t-set="google_maps_lang_localization" t-value="request.env['ir.config_parameter'].sudo().get_param('google.lang_localization')"/>
-        <t t-set="google_maps_region_localization" t-value="request.env['ir.config_parameter'].sudo().get_param('google.region_localization')"/>
-        <t t-set="google_maps_libraries" t-value="request.env['ir.config_parameter'].sudo().get_param('google.maps_libraries')"/>
+        <t t-set="google_maps_api_key" t-value="request.env['ir.config_parameter'].sudo().get_param('google.api_key_geocode', default='')"/>
+        <t t-set="google_maps_lang_localization" t-value="request.env['ir.config_parameter'].sudo().get_param('web_google_maps.localization_lang', default='')"/>
+        <t t-set="google_maps_region_localization" t-value="request.env['ir.config_parameter'].sudo().get_param('web_google_maps.localization_region', default='')"/>
+        <t t-set="google_maps_libraries" t-value="request.env['ir.config_parameter'].sudo().get_param('web_google_maps.maps_libraries', default='')"/>
         <script src="/web_google_maps/static/lib/markercluster/markerclusterer.js"></script>
+        <t t-set="google_lang" t-value="'&amp;language=' + google_maps_lang_localization if google_maps_lang_localization else ''"/>
+        <t t-set="google_region" t-value="'&amp;region=' + google_maps_region_localization if google_maps_region_localization else ''"/>
         <t t-if="google_maps_api_key">
-            <script t-attf-src="https://maps.googleapis.com/maps/api/js?v=quarterly&amp;key=#{google_maps_api_key}&amp;libraries=#{google_maps_libraries}#{google_maps_lang_localization}#{google_maps_region_localization}"></script>
+            <script t-attf-src="https://maps.googleapis.com/maps/api/js?v=quarterly&amp;key=#{google_maps_api_key}&amp;libraries=#{google_maps_libraries}#{google_lang}#{google_region}"></script>
         </t>
-        <t t-if="not google_maps_api_key">
-            <script t-attf-src="https://maps.googleapis.com/maps/api/js?v=quarterly&amp;libraries=#{google_maps_libraries}#{google_maps_lang_localization}#{google_maps_region_localization}"></script>
+        <t t-else="">
+            <script t-attf-src="https://maps.googleapis.com/maps/api/js?v=quarterly&amp;libraries=#{google_maps_libraries}#{google_lang}#{google_region}"></script>
         </t>
     </template>
     <template id="webclient_bootstrap" name="webclient_bootstrap gmaps" inherit_id="web.webclient_bootstrap">

--- a/web_google_maps/views/res_config_settings.xml
+++ b/web_google_maps/views/res_config_settings.xml
@@ -11,7 +11,7 @@
                     <div name="web_google_maps">
                         <h2>Google Maps View</h2>
                         <div class="row mt16 o_settings_container">
-                            <div class="col-xs-12 col-md-6 o_setting_box">
+                            <div class="col-12 col-lg-6 o_setting_box">
                                 <div class="o_setting_right_pane">
                                     <!-- <label string="Configure your Google Maps View"/> -->
                                     <div class="text-muted">
@@ -41,30 +41,65 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                        <h2> Google Maps Libraries </h2>
-                        <div class="row mt16 o_settings_container">
-                            <div class="col-xs-12 col-md-6 o_setting_box">
+                            <div class="col-12 col-lg-6 o_setting_box" attrs="{'invisible': [('google_maps_lang_localization', '=', False)]}">
                                 <div class="o_setting_left_pane">
-                                    <field name="google_maps_geometry"/>
+                                    <field name="google_autocomplete_lang_restrict"/>
                                 </div>
                                 <div class="o_setting_right_pane">
-                                    <label for="google_maps_geometry"/>
+                                    <label for="google_autocomplete_lang_restrict"/>
                                     <div class="text-muted">
-                                        Geometry includes utility functions for calculating scalar geometric values (such as distance and area) on the surface of the earth. 
-                                        Consult the <a href="https://developers.google.com/maps/documentation/javascript/geometry">Geometry library documentation</a> for more information.
+                                        The language code, indicating in which language the results should be returned, if possible. Searches are also biased to the selected language; results in the selected language may be given a higher ranking.
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-xs-12 col-md-6 o_setting_box">
+                        </div>
+                        <h2 groups="base.group_no_one"> Google Maps Libraries </h2>
+                        <div class="row mt16 o_settings_container" groups="base.group_no_one">
+                            <div class="col-12 col-lg-6 o_setting_box">
                                 <div class="o_setting_left_pane">
-                                    <field name="google_maps_places"/>
+                                    <field name="google_maps_lib_geometry"/>
                                 </div>
                                 <div class="o_setting_right_pane">
-                                    <label for="google_maps_places"/>
+                                    <label for="google_maps_lib_geometry"/>
+                                    <div class="text-muted">
+                                        Geometry includes utility functions for calculating scalar geometric values (such as distance and area) on the surface of the earth. 
+                                        Consult the <a href="https://developers.google.com/maps/documentation/javascript/geometry" target="_blank">Geometry library documentation</a> for more information.
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-12 col-lg-6 o_setting_box">
+                                <div class="o_setting_left_pane">
+                                    <field name="google_maps_lib_places"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="google_maps_lib_places"/>
                                     <div class="text-muted">
                                         Places enables your application to search for places such as establishments, geographic locations, or prominent points of interest, within a defined area. 
-                                        Consult the <a href="https://developers.google.com/maps/documentation/javascript/places">Places library documentation</a> for more information.
+                                        Consult the <a href="https://developers.google.com/maps/documentation/javascript/places" target="_blank">Places library documentation</a> for more information.
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-12 col-lg-6 o_setting_box" invisible="1">
+                                <div class="o_setting_left_pane">
+                                    <field name="google_maps_lib_drawing"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="google_maps_lib_drawing"/>
+                                    <div class="text-muted">
+                                        Drawing provides a graphical interface for users to draw polygons, rectangles, polylines, circles, and markers on the map.
+                                        Consult the <a href="https://developers.google.com/maps/documentation/javascript/drawinglayer" target="_blank">Drawing library documentation</a> for more information.
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-12 col-lg-6 o_setting_box" invisible="1">
+                                <div class="o_setting_left_pane">
+                                    <field name="google_maps_lib_visualization"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="google_maps_lib_visualization"/>
+                                    <div class="text-muted">
+                                        Visualization provides heatmaps for visual representation of data.
+                                        Consult the <a href="https://developers.google.com/maps/documentation/javascript/visualization" target="_blank">Visualization library documentation</a> for more information.
                                     </div>
                                 </div>
                             </div>

--- a/website_google_address_form/__manifest__.py
+++ b/website_google_address_form/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Website Google Address Form',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'author': 'Yopi Angi',
     'maintainer': 'Yopi Angi<yopiangi@gmail.com>',
     'support': 'yopiangi@gmail.com',

--- a/website_google_address_form/static/src/js/website_google_address_form.js
+++ b/website_google_address_form/static/src/js/website_google_address_form.js
@@ -70,11 +70,10 @@ odoo.define('website_google_address_form.address_form_autocomplete', function (r
         initAutocomplete: function (country_restrictions) {
             // Create the autocomplete object, restricting the search to geographical
             // location types.
-            this.place_autocomplete = new google.maps.places.Autocomplete(
-                (this.$target[0]), {
-                    types: ['geocode'],
-                }
-            );
+            this.place_autocomplete = new google.maps.places.Autocomplete(this.$target[0], {
+                types: ['geocode'],
+                fields: ['address_components', 'name', 'geometry'],
+            });
 
             // Add country restrictions if any
             if (country_restrictions.length) {
@@ -82,7 +81,6 @@ odoo.define('website_google_address_form.address_form_autocomplete', function (r
                     'country': country_restrictions
                 });
             }
-
             // When the user selects an address from the dropdown, populate the address
             // fields in the form.
             this.place_autocomplete.addListener('place_changed', this.fillInAddress.bind(this));
@@ -116,7 +114,9 @@ odoo.define('website_google_address_form.address_form_autocomplete', function (r
                         });
                     });
                 });
-                self.$target.val(place.name);
+                setTimeout(function () {
+                    self.$target.val(place.name);
+                }, 300);
             }
         },
         prepareValue: function (input, value) {
@@ -238,9 +238,9 @@ odoo.define('website_google_address_form.website_portal_form', function (require
                 return false;
             }
         });
-        $('input[name="street"]').on('focus', function () {
-            new GooglePlacesAutocomplete.AddressForm($(this), streetFillInputs);
-        });
+        if ($('input[name="street"]').length > 0) {
+            new GooglePlacesAutocomplete.AddressForm($('input[name="street"]'), streetFillInputs);
+        }
     });
 
 });
@@ -283,9 +283,9 @@ odoo.define('website_google_address_form.website_sale_form', function (require) 
     };
 
     $(document).ready(function () {
-        $('input[name="street"]').on('focus', function () {
-            new GooglePlacesAutocomplete.AddressForm($(this), streetFillInputs);
-        });
+        if ($('input[name="street"]').length > 0) {
+            new GooglePlacesAutocomplete.AddressForm($('input[name="street"]'), streetFillInputs);
+        }
     });
 
 });

--- a/website_google_address_form/views/res_config_settings.xml
+++ b/website_google_address_form/views/res_config_settings.xml
@@ -9,7 +9,7 @@
                 <div class="col-12 col-lg-6 o_setting_box" id="google_address_form_setting">
                     <div class="o_setting_right_pane">
                         <div class="mt16">
-                            <label for="google_maps_country_restriction" string="Address Form Autocomplete Country Restriction"/>
+                            <label for="google_maps_country_restriction" string="Website Address Form Autocomplete Country Restriction"/>
                             <div class="text-muted">
                                 Restrict results of google address form autocomplete to one or multiple countries
                             </div>

--- a/website_google_address_form/views/res_config_settings.xml
+++ b/website_google_address_form/views/res_config_settings.xml
@@ -3,17 +3,17 @@
     <record id="res_config_settings_view_form" model="ir.ui.view">
         <field name="name">res.config.settings.view.form.inherit.website_google_address_form</field>
         <field name="model">res.config.settings</field>
-        <field name="inherit_id" ref="website.res_config_settings_view_form"/>
+        <field name="inherit_id" ref="web_google_maps.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='google_maps_setting']" position="after">
-                <div class="col-xs-12 col-md-6 o_setting_box" id="google_address_form_setting">
+            <xpath expr="//div[@name='web_google_maps']/div[1]" position="inside">
+                <div class="col-12 col-lg-6 o_setting_box" id="google_address_form_setting">
                     <div class="o_setting_right_pane">
                         <div class="mt16">
-                            <label for="google_maps_country_restriction" string="Google Address Form Autocomplete Country Restriction"/>
+                            <label for="google_maps_country_restriction" string="Address Form Autocomplete Country Restriction"/>
                             <div class="text-muted">
                                 Restrict results of google address form autocomplete to one or multiple countries
                             </div>
-                            <field name="google_maps_country_restriction" nolabel="1" widget="many2many_tags"/>
+                            <field name="google_maps_country_restriction" nolabel="1" widget="many2many_tags" options="{'no_create_edit': True, 'no_create': True}"/>
                         </div>
                     </div>
                 </div>

--- a/website_google_address_form/views/template.xml
+++ b/website_google_address_form/views/template.xml
@@ -3,7 +3,7 @@
     <template id="frontend_layout" inherit_id="portal.frontend_layout" name="website_google_address_form layout">
         <xpath expr="//t[@t-call-assets='web.assets_common']" position="before">
             <t t-set="google_maps_api_key" t-value="request.env['ir.config_parameter'].sudo().get_param('google.api_key_geocode')"/>
-            <t t-set="google_maps_libraries" t-value="request.env['ir.config_parameter'].sudo().get_param('google.maps_libraries')"/>
+            <t t-set="google_maps_libraries" t-value="request.env['ir.config_parameter'].sudo().get_param('web_google_maps.maps_libraries', default='')"/>
             <t t-if="google_maps_api_key">
                 <script type="text/javascript" t-attf-src="https://maps.googleapis.com/maps/api/js?v=quarterly&amp;key=#{google_maps_api_key}&amp;libraries=#{google_maps_libraries}"/>
             </t>


### PR DESCRIPTION
- Fixed google autocomplete (address form) used at website that trigger multiple unnecessary API call
- Set fields at all Google autocomplete instance (to follow the recommendation from Google to avoid paying data that we do not need) Ref. https://developers.google.com/maps/billing/gmp-billing#ac-with-details-session
- Added a new setting for the autocomplete to allow user to specify language returned by the autocomplete (added a possibility for higher ranking) Ref. https://developers.google.com/places/web-service/autocomplete#place_autocomplete_requests