### PR TITLE
[FIX] Google map views markers located on the same coordinate

### DIFF
--- a/web_google_maps/static/src/js/view/google_map/google_map_renderer.js
+++ b/web_google_maps/static/src/js/view/google_map/google_map_renderer.js
@@ -320,6 +320,7 @@ odoo.define('web_google_maps.GoogleMapRenderer', function (require) {
                     }
                 });
             }
+            this.markerCluster.addMarker(marker);
             google.maps.event.addListener(
                 marker,
                 'click',
@@ -400,15 +401,7 @@ odoo.define('web_google_maps.GoogleMapRenderer', function (require) {
             const func_name = '_map_center_' + this.mapMode;
             this._clearMarkerClusters();
             this._renderMarkers();
-            this._clusterMarkers();
             return this._super.apply(this, arguments).then(this[func_name].bind(this));
-        },
-        /**
-         * Cluster markers
-         * @private
-         */
-        _clusterMarkers: function () {
-            this.markerCluster.addMarkers(this.markers);
         },
         /**
          * Centering map

--- a/web_google_maps/static/src/js/widgets/utils.js
+++ b/web_google_maps/static/src/js/widgets/utils.js
@@ -88,8 +88,6 @@ odoo.define('web_google_maps.Utils', function (require) {
      * @param {*} state
      */
     function fetchCountryState(model, country, state) {
-        var def = $.Deferred();
-
         if (model && country && state) {
             return new Promise(async (resolve) => {
                 const data = await rpc.query({
@@ -145,11 +143,7 @@ odoo.define('web_google_maps.Utils', function (require) {
         let vals;
         _.each(place_options, (option, field) => {
             if (option instanceof Array && !_.has(values, field)) {
-                vals = _.filter(
-                    _.map(option, function (opt) {
-                        return place[opt] || false;
-                    })
-                );
+                vals = _.filter(_.map(option, (opt) => place[opt] || false));
                 values[field] = _.first(vals) || '';
             } else {
                 values[field] = place[option] || '';


### PR DESCRIPTION
- Fixed the bug on cluster markers or multiple records located on the same coordinate. When the marker is clicked, it's only showing one record
