### PR TITLE
[14.0] Meeting maps

### DIFF
--- a/calendar_location/__init__.py
+++ b/calendar_location/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/calendar_location/__manifest__.py
+++ b/calendar_location/__manifest__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Calendar Location',
+    'version': '14.0.1.0.1',
+    'author': 'Yopi Angi',
+    'license': 'AGPL-3',
+    'maintainer': 'Yopi Angi<yopiangi@gmail.com>',
+    'support': 'yopiangi@gmail.com',
+    'category': 'Tools',
+    'description': """
+Calendar Location
+=================
+
+Added map view on calendar
+""",
+    'depends': ['calendar', 'contacts_maps'],
+    'website': '',
+    'data': [
+        'views/calendar_event.xml'
+    ],
+    'demo': [],
+    'installable': True
+}

--- a/calendar_location/i18n/calendar_location.pot
+++ b/calendar_location/i18n/calendar_location.pot
@@ -1,0 +1,103 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* calendar_location
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-06-26 13:16+0000\n"
+"PO-Revision-Date: 2021-06-26 13:16+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "&amp;nbsp;"
+msgstr ""
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "<span> &amp;nbsp; </span>"
+msgstr ""
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "Attendees"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.model,name:calendar_location.model_calendar_event
+msgid "Calendar Event"
+msgstr ""
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "Description"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.model.fields,field_description:calendar_location.field_calendar_event__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "End Date"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.model.fields,field_description:calendar_location.field_calendar_event__location_latitude
+msgid "Geo Latitude"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.model.fields,field_description:calendar_location.field_calendar_event__location_longitude
+msgid "Geo Longitude"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.actions.act_window,name:calendar_location.action_view_meeting_google_map
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_form_inherit
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "Google Map"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.model.fields,field_description:calendar_location.field_calendar_event__id
+msgid "ID"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.model.fields,field_description:calendar_location.field_calendar_event____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "Location"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.model.fields,field_description:calendar_location.field_calendar_event__marker_color
+msgid "Marker Color"
+msgstr ""
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "Responsible"
+msgstr ""
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "Start Date"
+msgstr ""
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "hours"
+msgstr ""

--- a/calendar_location/i18n/fr_BE.po
+++ b/calendar_location/i18n/fr_BE.po
@@ -1,0 +1,103 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* calendar_location
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-06-26 14:11+0000\n"
+"PO-Revision-Date: 2021-06-26 14:11+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "&amp;nbsp;"
+msgstr ""
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "<span> &amp;nbsp; </span>"
+msgstr ""
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "Attendees"
+msgstr "Participants"
+
+#. module: calendar_location
+#: model:ir.model,name:calendar_location.model_calendar_event
+msgid "Calendar Event"
+msgstr "Calendrier de l'événement"
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "Description"
+msgstr "Description"
+
+#. module: calendar_location
+#: model:ir.model.fields,field_description:calendar_location.field_calendar_event__display_name
+msgid "Display Name"
+msgstr "Nom affiché"
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "End Date"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.model.fields,field_description:calendar_location.field_calendar_event__location_latitude
+msgid "Geo Latitude"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.model.fields,field_description:calendar_location.field_calendar_event__location_longitude
+msgid "Geo Longitude"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.actions.act_window,name:calendar_location.action_view_meeting_google_map
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_form_inherit
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "Google Map"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.model.fields,field_description:calendar_location.field_calendar_event__id
+msgid "ID"
+msgstr ""
+
+#. module: calendar_location
+#: model:ir.model.fields,field_description:calendar_location.field_calendar_event____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "Location"
+msgstr "Emplacement"
+
+#. module: calendar_location
+#: model:ir.model.fields,field_description:calendar_location.field_calendar_event__marker_color
+msgid "Marker Color"
+msgstr ""
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "Responsible"
+msgstr "Responsable"
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "Start Date"
+msgstr "Date de début"
+
+#. module: calendar_location
+#: model_terms:ir.ui.view,arch_db:calendar_location.view_calendar_event_google_map
+msgid "hours"
+msgstr "heures"

--- a/calendar_location/models/__init__.py
+++ b/calendar_location/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import calendar_event

--- a/calendar_location/models/calendar_event.py
+++ b/calendar_location/models/calendar_event.py
@@ -25,5 +25,14 @@ class CalendarEvent(models.Model):
             res['location_longitude'] = partner_id.partner_longitude
         return res
 
+    @api.depends('start')
+    def _compute_marker_color(self):
+        for rec in self:
+            if rec.start < fields.Datetime.now():
+                rec.marker_color = 'red'
+            else:
+                rec.marker_color = 'green'
+
     location_latitude = fields.Float('Geo Latitude', digits=(16, 5))
     location_longitude = fields.Float('Geo Longitude', digits=(16, 5))
+    marker_color = fields.Char(compute='_compute_marker_color')

--- a/calendar_location/models/calendar_event.py
+++ b/calendar_location/models/calendar_event.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class CalendarEvent(models.Model):
+    _inherit = 'calendar.event'
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        context = self.env.context
+        if context.get('active_model') in (
+            'crm.lead',
+            'res.partner',
+        ) and context.get('partner_id'):
+            partner_id = self.env['res.partner'].browse(context['partner_id'])
+            address = ''
+            if partner_id.contact_address:
+                address = ', '.join(
+                    filter(None, partner_id.contact_address.split('\n')[1:])
+                )
+
+            res['location'] = address
+            res['location_latitude'] = partner_id.partner_latitude
+            res['location_longitude'] = partner_id.partner_longitude
+        return res
+
+    location_latitude = fields.Float('Geo Latitude', digits=(16, 5))
+    location_longitude = fields.Float('Geo Longitude', digits=(16, 5))

--- a/calendar_location/views/calendar_event.xml
+++ b/calendar_location/views/calendar_event.xml
@@ -1,26 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <record id="view_calendar_event_form_inherit" model="ir.ui.view">
-        <field name="name">view.calendar.event.form.inherit</field>
-        <field name="model">calendar.event</field>
-        <field name="priority">3000</field>
-        <field name="inherit_id" ref="calendar.view_calendar_event_form"/>
-        <field name="arch" type="xml">
-            <field name="location" position="attributes">
-                <attribute name="widget">gplaces_address_autocomplete</attribute>
-                <attribute name="options">{'mode': 'no_address_format', 'lat': 'location_latitude', 'lng': 'location_longitude', 'display_name': 'formatted_address', 'types': []}</attribute>
-            </field>
-            <field name="location" position="after">
-                <field name="location_latitude" invisible="1"/>
-                <field name="location_longitude" invisible="1"/>
-            </field>
-        </field>
-    </record>
     <record id="view_calendar_event_google_map" model="ir.ui.view">
         <field name="name">view.calendar.event.google_map</field>
         <field name="model">calendar.event</field>
         <field name="arch" type="xml">
-            <google_map string="Google Map" lat="location_latitude" lng="location_longitude">
+            <google_map string="Google Map" lat="location_latitude" lng="location_longitude" color="marker_color">
                 <field name="id"/>
                 <field name="location_latitude"/>
                 <field name="location_longitude"/>
@@ -34,6 +18,7 @@
                 <field name="attendee_status"/>
                 <field name="user_id"/>
                 <field name="description"/>
+                <field name="marker_color"/>
                 <templates>
                     <t t-name="kanban-box">
                         <div class="oe_kanban_global_click">
@@ -82,5 +67,35 @@
     </record>
     <record id="calendar.action_view_calendar_event_form" model="ir.actions.act_window.view">
         <field name="sequence" eval="4"/>
+    </record>
+    <record id="action_view_meeting_google_map" model="ir.actions.act_window">
+        <field name="name">Google Map</field>
+        <field name="res_model">calendar.event</field>
+        <field name="view_mode">google_map</field>
+        <field name="view_id" ref="calendar_location.view_calendar_event_google_map"/>
+        <field name="domain">[('id', '=', active_id)]</field>
+    </record>
+    <record id="view_calendar_event_form_inherit" model="ir.ui.view">
+        <field name="name">view.calendar.event.form.inherit</field>
+        <field name="model">calendar.event</field>
+        <field name="priority">3000</field>
+        <field name="inherit_id" ref="calendar.view_calendar_event_form"/>
+        <field name="arch" type="xml">
+            <field name="location" position="attributes">
+                <attribute name="widget">gplaces_address_autocomplete</attribute>
+                <attribute name="options">{'mode': 'no_address_format', 'lat': 'location_latitude', 'lng': 'location_longitude', 'display_name': 'formatted_address', 'types': []}</attribute>
+            </field>
+            <field name="location" position="after">
+                <field name="location_latitude" invisible="1"/>
+                <field name="location_longitude" invisible="1"/>
+            </field>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="%(calendar_location.action_view_meeting_google_map)d" 
+                    type="action" 
+                    class="oe_stat_button" 
+                    icon="fa-map-marker" string="Google Map" 
+                    attrs="{'invisible': ['|',('location_latitude', '=', 0.0), ('location_longitude', '=', 0.0)]}"/>
+            </xpath>
+        </field>
     </record>
 </odoo>

--- a/calendar_location/views/calendar_event.xml
+++ b/calendar_location/views/calendar_event.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_calendar_event_form_inherit" model="ir.ui.view">
+        <field name="name">view.calendar.event.form.inherit</field>
+        <field name="model">calendar.event</field>
+        <field name="priority">3000</field>
+        <field name="inherit_id" ref="calendar.view_calendar_event_form"/>
+        <field name="arch" type="xml">
+            <field name="location" position="attributes">
+                <attribute name="widget">gplaces_address_autocomplete</attribute>
+                <attribute name="options">{'mode': 'no_address_format', 'lat': 'location_latitude', 'lng': 'location_longitude', 'display_name': 'formatted_address', 'types': []}</attribute>
+            </field>
+            <field name="location" position="after">
+                <field name="location_latitude" invisible="1"/>
+                <field name="location_longitude" invisible="1"/>
+            </field>
+        </field>
+    </record>
+    <record id="view_calendar_event_google_map" model="ir.ui.view">
+        <field name="name">view.calendar.event.google_map</field>
+        <field name="model">calendar.event</field>
+        <field name="arch" type="xml">
+            <google_map string="Google Map" lat="location_latitude" lng="location_longitude">
+                <field name="id"/>
+                <field name="location_latitude"/>
+                <field name="location_longitude"/>
+                <field name="name"/>
+                <field name="start" string="Start Date"/>
+                <field name="stop_date" string="End Date"/>
+                <field name="location"/>
+                <field name="duration" readonly="1"/>
+                <field name="partner_ids" readonly="1"/>
+                <field name="alarm_ids" readonly="1"/>
+                <field name="attendee_status"/>
+                <field name="user_id"/>
+                <field name="description"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_global_click">
+                            <div class="oe_kanban_details">
+                                <div class="o_kanban_record_title text-center">
+                                    <h4><field name="name"/></h4>
+                                    <div class="mb-4">
+                                        <span class="fa fa-calendar-o">&amp;nbsp; <t t-esc="moment(record.start.raw_value).format('LLLL')"/></span>
+                                        <span> &amp;nbsp; </span>
+                                        <span class="fa fa-clock-o">&amp;nbsp; <field name="duration"/> hours</span>
+                                    </div>
+                                </div>
+                                <dl class="row mt-2">
+                                    <dt class="col-sm-3">Responsible</dt>
+                                    <dd class="col-sm-9">
+                                        <field name="user_id" string="Responsible" filters="1" widget="many2one_avatar_user"/>
+                                    </dd>
+                                    <dt class="col-sm-3">Attendees</dt>
+                                    <dd class="col-sm-9">
+                                        <field name="partner_ids" widget="many2many_tags_avatar" write_model="calendar.contacts" write_field="partner_id" avatar_field="image_128"/>
+                                    </dd>
+                                    <dt class="col-sm-3">Location</dt>
+                                    <dd class="col-sm-9">
+                                        <field name="location"/>
+                                    </dd>
+                                    <dt class="col-sm-3">Description</dt>
+                                    <dd class="col-sm-9">
+                                        <field name="description"/>
+                                    </dd>
+                                </dl>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </google_map>
+        </field>
+    </record>
+    <record id="calendar.action_calendar_event" model="ir.actions.act_window">
+        <field name="view_mode">calendar,tree,google_map,form</field>
+    </record>
+    <record id="action_view_calendar_event_google_map" model="ir.actions.act_window.view">
+        <field name="act_window_id" ref="calendar.action_calendar_event"/>
+        <field name="sequence" eval="3"/>
+        <field name="view_mode">google_map</field>
+        <field name="view_id" ref="view_calendar_event_google_map"/>
+    </record>
+    <record id="calendar.action_view_calendar_event_form" model="ir.actions.act_window.view">
+        <field name="sequence" eval="4"/>
+    </record>
+</odoo>

--- a/contacts_google_address_form/views/res_partner.xml
+++ b/contacts_google_address_form/views/res_partner.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <record id="view_contacts_google_address_form_inherit" model="ir.ui.view">
         <field name="name">Contacts Google Address Form Auto Complete</field>

--- a/web_google_maps/README.md
+++ b/web_google_maps/README.md
@@ -7,9 +7,9 @@ This module contains three new features:
  
 
 # Map view  `"google_map"`
-Basically, this new view `map`  will integrate Google Maps into Odoo.    
-Enable you to display `res.partner` geolocation on map or any model contains geolocation.   
-This feature will work seamlessly with Odoo means you can search your partner location using Odoo search feature.     
+Basically, this new view `google_map`  will integrate Google Maps into Odoo.    
+Enable you to display `res.partner` geolocation on map or any model contains geolocation fields.   
+This feature will work seamlessly with Odoo means user can do search on this new view like user do search on Odoo build-in view.     
 
 There are five available attributes that you can customize
  - `lat` : an attritube to tell the map the latitude field on the object __[mandatory]__
@@ -129,11 +129,25 @@ Example:
 
 New widget to integrate [Place Autocomplete Address Form](https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform) in Odoo.  
 The widget has four options that can be modify:
- - `component_form`
- - `fillfields`
- - `lat`
- - `lng`
-
+ - `component_form`    
+  Google component address
+ - `fillfields`   
+  List of fields the widget will automatically fulfil based on address results return from the autocomplete.
+ - `lat`    
+  Latitude field of your model
+ - `lng`    
+  Longitude field of your model
+ - `display_name`    
+  Property of google autocomplete that you want to take as value
+ - `types`    
+  Google autocomplete types. [Please check this documentation for more detail](https://developers.google.com/maps/documentation/places/web-service/supported_types#table3).
+  Default value:    
+   `gplaces_address_autocomplete`: `["establishment"]`
+   `gplaces_address_autocomplete`: `["address"]`
+ - `mode` (only support widget `gplaces_address_autocomplete`)    
+   Available value:     
+   - `address_format`
+   - `no_address_format`. Used this value if you simply just want to take the address without automatically fulfill other fields.
 ### Component form `component_form`
 Is an option used to modify which value you want to take from an objects returned by the geocoder.    
 Full documentation about Google component types can be found [here](https://developers.google.com/maps/documentation/geocoding/intro#Types)
@@ -191,7 +205,7 @@ Example:
 
 ### Fill fields `fillfields`
 Is an option that will be influenced by `gplaces_address_autocomplete` widget.    
-This options should contains known `fields` that you want the widget to fulfill a value for each given field automatically.    
+This options should contains known `fields`(address fields) that you want the widget to fulfill a value for each given field automatically (based on selected address from the search result).    
 A field can contains one or multiple elements of component form    
 By default this options are configured like the following
 ```javascript
@@ -255,7 +269,7 @@ By default this options are configured like following value:
 ```
 # Technical
 This module will install `base_setup` and `base_geolocalize`.    
-*I recommend you to setup __Google Maps Key API__ and add it into Odoo `Settings > General` Settings when you installed this module*
+*I recommend you to setup __Google Maps Key API__ and add it into Odoo `Settings > General > Google Maps View` section when you installed this module*
 
 *__List of Google APIs & services required in order to make all features works__*
 - Geocoding API
@@ -263,7 +277,3 @@ This module will install `base_setup` and `base_geolocalize`.
 - Places API
 
 Visit this [page](https://developers.google.com/maps/documentation/javascript/get-api-key) of how to get Google API Key
-
-
-[![ko-fi](https://www.ko-fi.com/img/donate_sm.png)](https://ko-fi.com/P5P4FOM0)    
-*if you want to support me to keep this project maintained. Thanks :)*

--- a/web_google_maps/__manifest__.py
+++ b/web_google_maps/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Web Google Maps',
-    'version': '14.0.1.0.1',
+    'version': '14.0.1.0.2',
     'author': 'Yopi Angi',
     'license': 'AGPL-3',
     'maintainer': 'Yopi Angi<yopiangi@gmail.com>',

--- a/web_google_maps/controllers/main.py
+++ b/web_google_maps/controllers/main.py
@@ -24,9 +24,15 @@ class Main(http.Controller):
             )
         )
         lang = get_param('web_google_maps.lang_localization', default=False)
+        region = get_param(
+            'web_google_maps.region_localization', default=False
+        )
 
         result = {}
-        if is_lang_restrict and lang:
-            result['language'] = lang
+        if is_lang_restrict:
+            if lang:
+                result['language'] = lang
+            if region:
+                result['region'] = region.lower()
 
         return result

--- a/web_google_maps/static/src/js/view/google_map/google_map_renderer.js
+++ b/web_google_maps/static/src/js/view/google_map/google_map_renderer.js
@@ -12,6 +12,8 @@ odoo.define('web_google_maps.GoogleMapRenderer', function (require) {
     const qweb = core.qweb;
     const _lt = core._lt;
 
+    // Normally any color can be used here (not limited to these colors)
+    // as we used SVG for the marker
     const MARKER_COLORS = [
         'black',
         'blue',
@@ -282,14 +284,16 @@ odoo.define('web_google_maps.GoogleMapRenderer', function (require) {
          * @param {string} color
          */
         _createMarker: function (latLng, record, color) {
+            const icon = Utils.svgMarker;
             const options = {
                 position: latLng,
                 map: this.gmap,
                 animation: google.maps.Animation.DROP,
                 _odooRecord: record,
+                icon: icon,
             };
             if (color) {
-                options.icon = this._getIconColorPath(color);
+                options.icon.fillColor = color;
             }
             const marker = new google.maps.Marker(options);
             this.markers.push(marker);
@@ -298,6 +302,7 @@ odoo.define('web_google_maps.GoogleMapRenderer', function (require) {
         /**
          * Get marker icon color path
          * @param {String} color
+         * 2021/06/27 Depricated (replaced by svg marker)
          */
         _getIconColorPath: function (color) {
             const defaultPath = '/web_google_maps/static/src/img/markers/';
@@ -316,6 +321,7 @@ odoo.define('web_google_maps.GoogleMapRenderer', function (require) {
                 const position = marker.getPosition();
                 markerInClusters.forEach(function (_cMarker) {
                     if (position && position.equals(_cMarker.getPosition())) {
+                        _cMarker.setMap(null);
                         existingRecords.push(_cMarker._odooRecord);
                     }
                 });

--- a/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js
+++ b/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js
@@ -261,6 +261,12 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
          * @override
          */
         prepareWidgetOptions: function () {
+            if (Object.prototype.hasOwnProperty.call(this.attrs.options, 'mode')) {
+                this.address_mode =
+                    Utils.ADDRESS_MODE.indexOf(this.attrs.options.mode) != -1
+                        ? this.attrs.options.mode
+                        : 'address_format';
+            }
             if (this.mode === 'edit' && this.attrs.options) {
                 if (this.attrs.options.hasOwnProperty('fillfields')) {
                     this.fillfields = _.defaults(
@@ -268,12 +274,6 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
                         this.attrs.options.fillfields,
                         this.fillfields
                     );
-                }
-                if (Object.prototype.hasOwnProperty.call(this.attrs.options, 'mode')) {
-                    this.address_mode =
-                        Utils.ADDRESS_MODE.indexOf(this.attrs.options.mode) != -1
-                            ? this.attrs.options.mode
-                            : 'address_format';
                 }
                 if (Object.prototype.hasOwnProperty.call(this.attrs.options, 'types')) {
                     this.autocomplete_types = this.attrs.options.types;
@@ -464,6 +464,9 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
             this.autocomplete_types = ['establishment'];
         },
         prepareWidgetOptions: function () {
+            if (Object.prototype.hasOwnProperty.call(this.attrs.options, 'mode')) {
+                console.warn('Option `mode` are not supported!');
+            }
             if (this.mode === 'edit' && this.attrs.options) {
                 if (Object.prototype.hasOwnProperty.call(this.attrs.options, 'force_override')) {
                     this.force_override = true;

--- a/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js
+++ b/web_google_maps/static/src/js/widgets/gplaces_autocomplete.js
@@ -250,6 +250,12 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
                 [this.address_form.state_id]: 'administrative_area_level_1',
                 [this.address_form.country_id]: 'country',
             };
+            // possible value: `address_format` or `no_address_format`
+            // address_format: widget will populate address returned by Google to Odoo address fields 
+            // no_address_format: no populate address, will take address and the geolocation data.
+            this.address_mode = 'address_format';
+            // Autocomplete request types
+            this.autocomplete_types = ['address'];
         },
         /**
          * @override
@@ -263,6 +269,15 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
                         this.fillfields
                     );
                 }
+                if (Object.prototype.hasOwnProperty.call(this.attrs.options, 'mode')) {
+                    this.address_mode =
+                        Utils.ADDRESS_MODE.indexOf(this.attrs.options.mode) != -1
+                            ? this.attrs.options.mode
+                            : 'address_format';
+                }
+                if (Object.prototype.hasOwnProperty.call(this.attrs.options, 'types')) {
+                    this.autocomplete_types = this.attrs.options.types;
+                }
             }
             this._super();
         },
@@ -272,8 +287,7 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
          */
         getFillFieldsType: function () {
             const res = this._super();
-
-            if (this._isValid) {
+            if (this._isValid && this.address_mode === 'address_format') {
                 _.each(Object.keys(this.fillfields), (field_name) => {
                     res.push({
                         name: field_name,
@@ -289,7 +303,14 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
          */
         handlePopulateAddress: function () {
             const place = this.places_autocomplete.getPlace();
-            if (place.hasOwnProperty('address_components')) {
+            if (this.address_mode === 'no_address_format') {
+                const location_geometry = this._setGeolocation(
+                    place.geometry.location.lat(),
+                    place.geometry.location.lng()
+                );
+                this.$input.val(place[this.display_name] || place.name);
+                this._onUpdateWidgetFields(location_geometry);
+            } else if (place.hasOwnProperty('address_components')) {
                 const google_address = this._populateAddress(place);
                 this.populateAddress(place, google_address);
                 this.$input.val(place.name);
@@ -356,8 +377,8 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
                         this.places_autocomplete = new google.maps.places.Autocomplete(
                             this.$input.get(0),
                             {
-                                types: ['address'],
-                                fields: ['address_components', 'name', 'geometry'],
+                                types: this.autocomplete_types,
+                                fields: ['address_components', 'name', 'geometry', 'formatted_address'],
                             }
                         );
                         if (this.autocomplete_settings) {
@@ -378,12 +399,24 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
          */
         isValid: function () {
             this._super.apply(this, arguments);
-            const unknown_fields = _.filter(
-                _.keys(this.fillfields),
-                (field) => !this.record.fields.hasOwnProperty(field)
-            );
             this._isValid = true;
-            if (unknown_fields.length > 0) {
+            let unknown_fields;
+            if (this.address_mode === 'address_format') {
+                let fields = _.keys(this.fillfields);
+                if (this.lat && this.lng) {
+                    fields = fields.concat([this.lat, this.lng]);
+                }
+                unknown_fields = _.filter(
+                    fields,
+                    (field) => !this.record.fields.hasOwnProperty(field)
+                );
+            } else if (this.address_mode === 'no_address_format' && this.lat && this.lng) {
+                unknown_fields = _.filter(
+                    [this.lat, this.lng],
+                    (field) => !this.record.fields.hasOwnProperty(field)
+                );
+            }
+            if (unknown_fields && unknown_fields.length > 0) {
                 this.do_warn(
                     _t('The following fields are invalid:'),
                     _t('<ul><li>' + unknown_fields.join('</li><li>') + '</li></ul>')
@@ -426,6 +459,9 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
                     country_id: 'country',
                 },
             };
+            this.address_mode = 'address_format';
+            // Autocomplete request types
+            this.autocomplete_types = ['establishment'];
         },
         prepareWidgetOptions: function () {
             if (this.mode === 'edit' && this.attrs.options) {
@@ -464,7 +500,7 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
         },
         getFillFieldsType: function () {
             const res = this._super();
-            if (this._isValid) {
+            if (this._isValid && this.address_mode === 'address_format') {
                 _.each(this.fillfields, (option) => {
                     _.each(Object.keys(option), (field_name) => {
                         res.push({
@@ -562,7 +598,7 @@ odoo.define('web_google_maps.GplaceAutocompleteFields', function (require) {
                         this.places_autocomplete = new google.maps.places.Autocomplete(
                             this.$input.get(0),
                             {
-                                types: ['establishment'],
+                                types: this.autocomplete_types,
                                 fields: [
                                     'address_components',
                                     'name',

--- a/web_google_maps/static/src/js/widgets/utils.js
+++ b/web_google_maps/static/src/js/widgets/utils.js
@@ -39,6 +39,17 @@ odoo.define('web_google_maps.Utils', function (require) {
         train_station: 'short_name',
         transit_station: 'short_name',
     };
+    const svgMarker = {
+        path: "M 12 12 c 3 0 3 -5 0 -5 c -3 0 -3 5 0 5 z M 12 2.016 q 2.906 0 4.945 2.039 t 2.039 4.945 q 0 1.453 -0.727 3.328 t -1.758 3.516 t -2.039 3.07 t -1.711 2.273 l -0.75 0.797 q -0.281 -0.328 -0.75 -0.867 t -1.688 -2.156 t -2.133 -3.141 t -1.664 -3.445 t -0.75 -3.375 q 0 -2.906 2.039 -4.945 t 4.945 -2.039 z",
+        fillColor: "blue",
+        fillOpacity: 1,
+        strokeWeight: 2,
+        strokeColor: "#ddd",
+        rotation: 1,
+        scale: 2,
+        anchor: new google.maps.Point(15, 30),
+    };
+
     /**
      * Mapping field with an alias
      * key: alias
@@ -1476,5 +1487,6 @@ odoo.define('web_google_maps.Utils', function (require) {
         gmaps_get_geolocation: gmaps_get_geolocation,
         fetchValues: fetchValues,
         fetchCountryState: fetchCountryState,
+        svgMarker: svgMarker
     };
 });

--- a/web_google_maps/static/src/js/widgets/utils.js
+++ b/web_google_maps/static/src/js/widgets/utils.js
@@ -52,6 +52,8 @@ odoo.define('web_google_maps.Utils', function (require) {
         state_id: 'state_id',
         country_id: 'country_id',
     };
+    const ADDRESS_MODE = ['address_format', 'no_address_format'];
+    const AUTOCOMPLETE_TYPES = ['geocode', 'address', 'establishment', 'regions', 'cities'];
 
     /**
      *
@@ -1467,6 +1469,8 @@ odoo.define('web_google_maps.Utils', function (require) {
         GOOGLE_PLACES_COMPONENT_FORM: GOOGLE_PLACES_COMPONENT_FORM,
         ADDRESS_FORM: ADDRESS_FORM,
         MAP_THEMES: MAP_THEMES,
+        ADDRESS_MODE: ADDRESS_MODE,
+        AUTOCOMPLETE_TYPES: AUTOCOMPLETE_TYPES,
         gmaps_populate_address: gmaps_populate_address,
         gmaps_populate_places: gmaps_populate_places,
         gmaps_get_geolocation: gmaps_get_geolocation,


### PR DESCRIPTION
- Added new module `calendar_location`
This module allows you to define meeting location from Google autocomplete and be able to show them on maps (google maps).
- Improved Google autocomplete widgets:
   - New option to format (populate Google autocomplete `address_component` into Odoo address fields) address or not. This option can be configured from fields view definition, example
   ```xml
    <field name="location" widget="gplaces_address_autocomplete" options="{'mode': 'no_address_format', ..}"/>
  ```
  Possible mode value: `no_address_format` & `address_format` (default)
   - New option to configure Google autocomplete types. Right now this setting is hardcoded and by this update, you can configured it via options, example
    ```xml
    <field name="location" widget="gplaces_address_autocomplete" options="{'types': [], ..}"/>
    ```
   Possible `types` values: ` 'geocode', 'address', 'establishment', 'regions', 'cities'`
   Google documentation https://developers.google.com/maps/documentation/places/web-service/supported_types#table3