### PR TITLE
IMP same adress format for places and adress complete

### DIFF
--- a/contacts_google_places_autocomplete_extended/__manifest__.py
+++ b/contacts_google_places_autocomplete_extended/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Contacts Google Places Autocomplete Extended',
-    'version': '14.0.1.0.0',
+    'version': '14.0.2.0.0',
     'author': 'Yopi Angi',
     'license': 'AGPL-3',
     'maintainer': 'Yopi Angi<yopiangi@gmail.com>',

--- a/contacts_google_places_autocomplete_extended/views/res_partner.xml
+++ b/contacts_google_places_autocomplete_extended/views/res_partner.xml
@@ -22,7 +22,8 @@
                             'partner_latitude': 'latitude',
                             'partner_longitude': 'longitude'
                         }
-                    }
+                    },
+                'force_override': true,
                 }</attribute>
             </field>
         </field>


### PR DESCRIPTION
Before:
streetnumber --> odoo street_name
streetname --> odoo street_number

After:
Street umber and streetname goes in the right fields. just as in adress complete module.

On a standard install the places autocomplete maps the fields different then the adress autocomplete module.
Took some time to find out all the overrides on the gmaps places autocomplete were not functioning.
Because of the missing `force_override` tag.

This commit adds the force_override tag. thus it is easier to find for other users.
As well it changes the behaviour so on a standard install the behaviour of gmaps autocomplete is similar to adress autocomplete.

