### PR TITLE
[14.0][IMP] web_google_maps: Add marker color by field function

### DIFF
--- a/web_google_maps/README.md
+++ b/web_google_maps/README.md
@@ -111,7 +111,8 @@ There are two attributes:
  - `colors`     
  Allow you to display different marker color to represent a record on map
  - `color`    
- One marker color for all records on map
+ One marker color for all records on map if a color is specified or different colors per group if a field is defined
+   (ex. partner_id or project_id)
 
 
 Example:
@@ -123,6 +124,11 @@ Example:
 
     <!-- color -->
     <google_map string="Map" lat="partner_latitude" lng="partner_longitude" color="orange">
+        ...
+    </google_map>
+
+    <!-- color field -->
+    <google_map string="Map" lat="partner_latitude" lng="partner_longitude" color="partner_id">
         ...
     </google_map>
 ```

--- a/web_google_maps/static/src/js/view/google_map/google_map_renderer.js
+++ b/web_google_maps/static/src/js/view/google_map/google_map_renderer.js
@@ -274,12 +274,18 @@ odoo.define('web_google_maps.GoogleMapRenderer', function (require) {
          * @return string
          */
         _getIconColor: function (record) {
-            if (this.markerColor) {
-                return this.markerColor;
-            }
-
-            if (!this.markerColors) {
-                return this.defaultMarkerColor;
+            const markerColor = this.markerColor
+            if (markerColor) {
+                const field = record.data[markerColor];
+                if (field && field.res_id) {
+                    const value = field.res_id;
+                    const color_index = _.isArray(value) ? value[0] % 18 : value % 18;
+                    return MARKER_COLORS[color_index];
+                } else if (typeof markerColor === 'string') {
+                    return markerColor;
+                } else {
+                    return this.defaultMarkerColor;
+                }
             }
 
             let color = null;

--- a/web_google_maps/static/src/scss/view_google_map.scss
+++ b/web_google_maps/static/src/scss/view_google_map.scss
@@ -178,6 +178,11 @@
                     font-size: 13px;
                 }
             }
+            .o_field_many2manytags {
+                .badge {
+                    float: left;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This commit makes it possible to specify a field_name in the color attribute. By using a field_name instead of color it groups records with an identical field relation into groups with the same color