### PR TITLE
[FIX] Disabled markerclusters does not reset markers created on previous render

### DIFF
--- a/web_google_maps/static/src/js/view/google_map/google_map_renderer.js
+++ b/web_google_maps/static/src/js/view/google_map/google_map_renderer.js
@@ -327,6 +327,8 @@ odoo.define('web_google_maps.GoogleMapRenderer', function (require) {
         clearMarkers: function () {
             if (this.markerCluster) {
                 this.markerCluster.clearMarkers();
+            } else {
+                this.markers.map((m) => m.setMap(null));
             }
             this.markers.splice(0);
         },


### PR DESCRIPTION
Disabled marker cluster doesn't reset markers created on previous render